### PR TITLE
Removed AttributionError trigger on null intents

### DIFF
--- a/src/main/java/com/mparticle/kits/ButtonKit.java
+++ b/src/main/java/com/mparticle/kits/ButtonKit.java
@@ -117,11 +117,6 @@ public class ButtonKit extends KitIntegration implements KitIntegration.Activity
                     .setLink(intent.getDataString())
                     .setServiceProviderId(getConfiguration().getKitId());
             getKitManager().onResult(result);
-        } else {
-            AttributionError attributionError = new AttributionError()
-                    .setMessage("No pending post-install deep link.")
-                    .setServiceProviderId(getConfiguration().getKitId());
-            getKitManager().onError(attributionError);
         }
 
         if (throwable != null) {

--- a/src/test/java/com/mparticle/kits/ButtonKitTests.java
+++ b/src/test/java/com/mparticle/kits/ButtonKitTests.java
@@ -134,14 +134,6 @@ public class ButtonKitTests {
     }
 
     @Test
-    public void onResult_shouldSetAttributionErrorOnNoIntent() {
-        buttonKit.onKitCreate(settings, context);
-        buttonKit.onResult(null, null);
-        assertThat(kitManager.error.getMessage()).isEqualTo("No pending post-install deep link.");
-        assertThat(kitManager.error.getServiceProviderId()).isEqualTo(TEST_KIT_ID);
-    }
-
-    @Test
     public void onActivityCreated_shouldTrackIncomingIntent() {
         Activity activity = mock(Activity.class);
         Intent intent = new Intent();


### PR DESCRIPTION
While we do not _check_ (network request to our backend) for a deferred deeplink after the first launch, we do however notify the listener every since time (with null intent and throwable). Because of that, we would be sending an `AttributionError` upon every launch.

If it is necessary to keep this error message, we could potentially add a flag to `SharedPreferences` but I am unsure if added functionality justifies the added overhead.