### PR TITLE
Allow clearing Merchant Library data

### DIFF
--- a/src/main/java/com/mparticle/kits/ButtonKit.java
+++ b/src/main/java/com/mparticle/kits/ButtonKit.java
@@ -66,6 +66,12 @@ public class ButtonKit extends KitIntegration implements KitIntegration.Activity
         return null;
     }
 
+    @Override
+    protected void reset() {
+        super.reset();
+        merchant.clearAllData(applicationContext);
+    }
+
     /*
      * Public methods to expose important Merchant Library methods
      */

--- a/src/main/java/com/mparticle/kits/ButtonMerchantWrapper.java
+++ b/src/main/java/com/mparticle/kits/ButtonMerchantWrapper.java
@@ -34,4 +34,8 @@ public class ButtonMerchantWrapper {
             PostInstallIntentListener listener) {
         ButtonMerchant.handlePostInstallIntent(context, listener);
     }
+
+    public void clearAllData(@NonNull Context context) {
+        ButtonMerchant.clearAllData(context);
+    }
 }

--- a/src/test/java/com/mparticle/kits/ButtonKitTests.java
+++ b/src/test/java/com/mparticle/kits/ButtonKitTests.java
@@ -163,6 +163,13 @@ public class ButtonKitTests {
         verify(merchant).trackIncomingIntent(context, intent);
     }
 
+    @Test
+    public void reset_shouldClearAllData() {
+        buttonKit.onKitCreate(settings, context);
+        buttonKit.reset();
+        verify(merchant).clearAllData(context);
+    }
+
     /*
      * Test Helpers
      */


### PR DESCRIPTION
This PR allows an mParticle Kit Consumer to clear all Merchant Library data by calling mParticle's `reset()` method.