### PR TITLE
Track commerce activity via Button Merchant Library

### DIFF
--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.2.50'
+    ext.kotlin_version = '1.3.72'
 
     repositories {
         google()
@@ -48,7 +48,7 @@ repositories {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.android.support:appcompat-v7:28.0.0-rc02'
+    implementation 'com.android.support:appcompat-v7:28.0.0'
     implementation 'com.android.support.constraint:constraint-layout:1.1.3'
 
     //    In production, import the ButtonKit like so:

--- a/sample/src/main/java/com/example/buttonkit/IntentActivity.kt
+++ b/sample/src/main/java/com/example/buttonkit/IntentActivity.kt
@@ -14,7 +14,7 @@ class IntentActivity : AppCompatActivity() {
 
         actionBar?.setDisplayShowHomeEnabled(true)
 
-        val button = MParticle.getInstance().getKitInstance(
+        val button = MParticle.getInstance()?.getKitInstance(
                 MParticle.ServiceProviders.BUTTON) as ButtonKit?
 
         tv_attribution_token.text = button?.attributionToken

--- a/sample/src/main/java/com/example/buttonkit/MainActivity.kt
+++ b/sample/src/main/java/com/example/buttonkit/MainActivity.kt
@@ -14,7 +14,7 @@ class MainActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 
-        val button = MParticle.getInstance().getKitInstance(
+        val button = MParticle.getInstance()?.getKitInstance(
                 MParticle.ServiceProviders.BUTTON) as ButtonKit?
 
         bt_attribution_refresh.setOnClickListener {

--- a/sample/src/main/java/com/example/buttonkit/MainActivity.kt
+++ b/sample/src/main/java/com/example/buttonkit/MainActivity.kt
@@ -3,19 +3,35 @@ package com.example.buttonkit
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
 import android.text.TextUtils
+import android.util.Log
 import com.mparticle.MParticle
+import com.mparticle.commerce.CommerceEvent
+import com.mparticle.commerce.Product
 import com.mparticle.kits.ButtonKit
+import kotlinx.android.synthetic.main.activity_main.bt_activity_add_to_cart
+import kotlinx.android.synthetic.main.activity_main.bt_activity_cart_view
+import kotlinx.android.synthetic.main.activity_main.bt_activity_product_view
 import kotlinx.android.synthetic.main.activity_main.bt_attribution_refresh
 import kotlinx.android.synthetic.main.activity_main.tv_attribution_token
 
 class MainActivity : AppCompatActivity() {
 
+    private val product: Product
+        get() {
+            val sku = (100000000000..999999999999).random().toString()
+            return Product.Builder("Product ${(0..10).random()}", sku, (10..99).random().toDouble())
+                    .category("samples")
+                    .quantity((1..10).random().toDouble())
+                    .customAttributes(mapOf(Pair("test-attr", "yes")))
+                    .build()
+        }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 
-        val button = MParticle.getInstance()?.getKitInstance(
-                MParticle.ServiceProviders.BUTTON) as ButtonKit?
+        val button = MParticle.getInstance()
+                ?.getKitInstance(MParticle.ServiceProviders.BUTTON) as ButtonKit?
 
         bt_attribution_refresh.setOnClickListener {
             val token = button?.attributionToken
@@ -27,5 +43,23 @@ class MainActivity : AppCompatActivity() {
             }
         }
 
+        bt_activity_product_view.setOnClickListener {
+            val event = CommerceEvent.Builder(Product.DETAIL, product).build()
+            MParticle.getInstance()?.logEvent(event) ?: logKitUnavailable()
+        }
+
+        bt_activity_add_to_cart.setOnClickListener {
+            val event = CommerceEvent.Builder(Product.ADD_TO_CART, product).build()
+            MParticle.getInstance()?.logEvent(event) ?: logKitUnavailable()
+        }
+
+        bt_activity_cart_view.setOnClickListener {
+            val event = CommerceEvent.Builder(Product.CHECKOUT, product).build()
+            MParticle.getInstance()?.logEvent(event) ?: logKitUnavailable()
+        }
+    }
+
+    private fun logKitUnavailable() {
+        Log.e("ButtonKitSample", "mParticle / ButtonKit is unavailable!")
     }
 }

--- a/sample/src/main/java/com/example/buttonkit/SampleApplication.kt
+++ b/sample/src/main/java/com/example/buttonkit/SampleApplication.kt
@@ -10,7 +10,7 @@ import com.mparticle.AttributionResult
 import com.mparticle.MParticle
 import com.mparticle.MParticleOptions
 
-class SampleApplication : Application() , AttributionListener{
+class SampleApplication : Application(), AttributionListener {
 
     private val TAG = "ButtonKitSample"
 
@@ -26,16 +26,16 @@ class SampleApplication : Application() , AttributionListener{
         MParticle.start(options)
     }
 
-    override fun onResult(result: AttributionResult?) {
-        if (result?.serviceProviderId == MParticle.ServiceProviders.BUTTON) {
+    override fun onResult(result: AttributionResult) {
+        if (result.serviceProviderId == MParticle.ServiceProviders.BUTTON) {
             val intent = Intent(Intent.ACTION_VIEW, Uri.parse(result.link))
             intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
             startActivity(intent)
         }
     }
 
-    override fun onError(error: AttributionError?) {
-        if (error?.serviceProviderId == MParticle.ServiceProviders.BUTTON) {
+    override fun onError(error: AttributionError) {
+        if (error.serviceProviderId == MParticle.ServiceProviders.BUTTON) {
             Log.e(TAG, "Attribution error: " + error.message)
         }
     }

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.widget.RelativeLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     tools:context=".MainActivity"
     >
 
@@ -11,7 +11,9 @@
         android:id="@+id/tv_attribution_title"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_centerHorizontal="true"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
         android:layout_marginTop="20dp"
         android:text="@string/title_token"
         style="@style/Base.TextAppearance.AppCompat.Title"
@@ -21,21 +23,57 @@
         android:id="@+id/tv_attribution_token"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_below="@id/tv_attribution_title"
-        android:layout_centerHorizontal="true"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tv_attribution_title"
         android:layout_marginTop="5dp"
         android:text="@string/label_default_token"
         style="@style/Base.TextAppearance.AppCompat.Body1"
         />
 
-    <android.support.v7.widget.AppCompatButton
-        android:id="@+id/bt_attribution_refresh"
-        android:layout_width="wrap_content"
+    <android.support.v7.widget.LinearLayoutCompat
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_centerHorizontal="true"
-        android:text="@string/label_refresh_token"
-        android:layout_centerVertical="true"
-        android:layout_marginTop="10dp"
-        />
+        android:gravity="center"
+        android:orientation="vertical"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        >
 
-</android.widget.RelativeLayout>
+        <android.support.v7.widget.AppCompatButton
+            android:id="@+id/bt_attribution_refresh"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="10dp"
+            android:text="@string/label_refresh_token"
+            />
+
+        <android.support.v7.widget.AppCompatButton
+            android:id="@+id/bt_activity_product_view"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="10dp"
+            android:text="@string/label_view_product"
+            />
+
+        <android.support.v7.widget.AppCompatButton
+            android:id="@+id/bt_activity_add_to_cart"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="10dp"
+            android:text="@string/label_add_product"
+            />
+
+        <android.support.v7.widget.AppCompatButton
+            android:id="@+id/bt_activity_cart_view"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="10dp"
+            android:text="@string/label_view_cart"
+            />
+
+    </android.support.v7.widget.LinearLayoutCompat>
+
+</android.support.constraint.ConstraintLayout>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -4,4 +4,7 @@
     <string name="label_default_token">No attribution token found!</string>
     <string name="label_default_token_intent">No attribution token was found in the deferred link!</string>
     <string name="label_refresh_token">Refresh Token</string>
+    <string name="label_view_product">Track "Product View"</string>
+    <string name="label_add_product">Track "Add To Cart"</string>
+    <string name="label_view_cart">Track "Cart View"</string>
 </resources>

--- a/src/main/java/com/mparticle/kits/ButtonMerchantWrapper.java
+++ b/src/main/java/com/mparticle/kits/ButtonMerchantWrapper.java
@@ -3,10 +3,14 @@ package com.mparticle.kits;
 import android.content.Context;
 import android.content.Intent;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import com.usebutton.merchant.ButtonMerchant;
 import com.usebutton.merchant.ButtonMerchant.AttributionTokenListener;
+import com.usebutton.merchant.ButtonProductCompatible;
 import com.usebutton.merchant.PostInstallIntentListener;
+
+import java.util.List;
 
 /**
  * Wrapper class for {@link ButtonMerchant} to allow for testing the library's static methods
@@ -37,5 +41,17 @@ public class ButtonMerchantWrapper {
 
     public void clearAllData(@NonNull Context context) {
         ButtonMerchant.clearAllData(context);
+    }
+
+    public void trackProductViewed(@Nullable ButtonProductCompatible product) {
+        ButtonMerchant.activity().productViewed(product);
+    }
+
+    public void trackAddToCart(@Nullable ButtonProductCompatible product) {
+        ButtonMerchant.activity().productAddedToCart(product);
+    }
+
+    public void trackCartViewed(@NonNull List<ButtonProductCompatible> products) {
+        ButtonMerchant.activity().cartViewed(products);
     }
 }

--- a/src/test/java/com/mparticle/kits/ButtonKitTests.java
+++ b/src/test/java/com/mparticle/kits/ButtonKitTests.java
@@ -8,16 +8,23 @@ import android.content.pm.PackageManager;
 import android.os.Build;
 import android.support.annotation.NonNull;
 
+import com.usebutton.merchant.ButtonProductCompatible;
+
 import com.mparticle.AttributionError;
 import com.mparticle.AttributionResult;
 import com.mparticle.MParticle;
+import com.mparticle.commerce.CommerceEvent;
+import com.mparticle.commerce.Product;
 import com.mparticle.identity.IdentityApi;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static com.mparticle.kits.ButtonKit.ATTRIBUTE_REFERRER;
@@ -26,6 +33,8 @@ import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 public class ButtonKitTests {
@@ -168,6 +177,87 @@ public class ButtonKitTests {
         buttonKit.onKitCreate(settings, context);
         buttonKit.reset();
         verify(merchant).clearAllData(context);
+    }
+
+    @Test
+    public void logEvent_noProductAction_shouldIgnoreCall() {
+        Product product = new Product.Builder("Test", "987", 1).build();
+        CommerceEvent event = new CommerceEvent.Builder(null, product).build();
+        buttonKit.logEvent(event);
+        verifyZeroInteractions(merchant);
+    }
+
+    @Test
+    public void logEvent_shouldConvertToButtonProduct() {
+        ArgumentCaptor<ButtonProductCompatible> productCaptor =
+                ArgumentCaptor.forClass(ButtonProductCompatible.class);
+        Product product = new Product.Builder("Test Name", "98765", 12.34)
+                .category("Test category")
+                .quantity(2)
+                .customAttributes(Collections.singletonMap("test_key", "test_value"))
+                .build();
+        CommerceEvent event = new CommerceEvent.Builder(Product.DETAIL, product).build();
+
+        buttonKit.logEvent(event);
+        verify(merchant).trackProductViewed(productCaptor.capture());
+        ButtonProductCompatible btnProduct = productCaptor.getValue();
+
+        assertThat(btnProduct).isNotNull();
+        assertThat(btnProduct.getId()).isEqualTo("98765");
+        assertThat(btnProduct.getName()).isEqualTo("Test Name");
+        assertThat(btnProduct.getValue()).isEqualTo((int) (12.34 * 100 * 2));
+        assertThat(btnProduct.getQuantity()).isEqualTo(2);
+        assertThat(btnProduct.getCategories()).isNotNull();
+        assertThat(btnProduct.getCategories().size()).isEqualTo(1);
+        assertThat(btnProduct.getCategories().get(0)).isEqualTo("Test category");
+        assertThat(btnProduct.getAttributes()).isNotNull();
+        assertThat(btnProduct.getAttributes()).hasSize(1);
+        assertThat(btnProduct.getAttributes()).containsEntry("btn_product_count", "1");
+        assertThat(btnProduct.getAttributes()).doesNotContainEntry("test_key", "test_value");
+    }
+
+    @Test
+    public void logEvent_detail_shouldTrackWithFirstProduct() {
+        Product product = new Product.Builder("Test", "987", 1).build();
+        CommerceEvent.Builder eventBuilder = new CommerceEvent.Builder(Product.DETAIL, product);
+        for (int i = 0; i < 20; i++) {
+            eventBuilder.addProduct(product);
+        }
+
+        buttonKit.logEvent(eventBuilder.build());
+
+        verify(merchant).trackProductViewed(any(ButtonProductCompatible.class));
+        verifyNoMoreInteractions(merchant);
+    }
+
+    @Test
+    public void logEvent_addToCart_shouldTrackWithFirstProduct() {
+        Product product = new Product.Builder("Test", "987", 1).build();
+        CommerceEvent.Builder eventBuilder = new CommerceEvent.Builder(Product.ADD_TO_CART, product);
+        for (int i = 0; i < 20; i++) {
+            eventBuilder.addProduct(product);
+        }
+
+        buttonKit.logEvent(eventBuilder.build());
+
+        verify(merchant).trackAddToCart(any(ButtonProductCompatible.class));
+        verifyNoMoreInteractions(merchant);
+    }
+
+    @Test
+    public void logEvent_checkoutViewed_shouldTrackWithAllProducts() {
+        ArgumentCaptor<List> listCaptor = ArgumentCaptor.forClass(List.class);
+        Product product = new Product.Builder("Test", "987", 1).build();
+        CommerceEvent.Builder eventBuilder = new CommerceEvent.Builder(Product.CHECKOUT, product);
+        for (int i = 0; i < 20; i++) {
+            eventBuilder.addProduct(product);
+        }
+
+        buttonKit.logEvent(eventBuilder.build());
+
+        verify(merchant).trackCartViewed(listCaptor.capture());
+        assertThat(listCaptor.getValue()).hasSize(21);
+        verifyNoMoreInteractions(merchant);
     }
 
     /*


### PR DESCRIPTION
This PR hooks the ButtonKit into the `CommerceListener` to listen to commerce events. For the following supported event names, the respective ML activity method is called:
- `view_detail` -> `ButtonMerchant.activity().productViewed(~)`
- `add_to_cart` -> `ButtonMerchant.activity().productAddedToCart(~)`
- `checkout` -> `ButtonMerchant.activity().cartViewed(~)`

It is important to note that these mappings are best-effort, since the consumer of the ButtonKit (an mParticle Partner) may design their system another way.

Additionally, tries to parse as much info from the mParticle `Product` into a `ButtonProductCompatible` which is used by the ML for activity reporting.